### PR TITLE
Move AVAILABLE_OPERATIONS declaration before DEFAULT_OPTIONS

### DIFF
--- a/common.js
+++ b/common.js
@@ -2,6 +2,14 @@ export function isPlainObject(wat) {
   return Object.prototype.toString.call(wat) === "[object Object]";
 }
 
+export const AVAILABLE_OPERATIONS = [
+  "select",
+  "insert",
+  "upsert",
+  "update",
+  "delete",
+];
+
 export const DEFAULT_OPTIONS = {
   tracing: true,
   breadcrumbs: true,
@@ -47,14 +55,6 @@ export function validateOption(availableOptions, key, value) {
     );
   }
 }
-
-export const AVAILABLE_OPERATIONS = [
-  "select",
-  "insert",
-  "upsert",
-  "update",
-  "delete",
-];
 
 export function extractOperation(method, headers = {}) {
   switch (method) {


### PR DESCRIPTION
This PR moves the declaration of AVAILABLE_OPERATIONS before DEFAULT_OPTIONS to fix `Uncaught TypeError: AVAILABLE_OPERATIONS is not iterable` or `Spread syntax requires ...iterable not be null or undefined` errors.

This should fix issue #10. 