### PR TITLE
chore: add minimum release age protection

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
## What

Adds a minimum-release-age guard so this repo will not install npm packages
newer than **3 days** old at install time.

- File added/updated: `.npmrc`
- Value: `3` (days — npm's `min-release-age` unit is days)

## Why

Recent npm supply-chain attacks (malicious versions of `chalk`, `debug`,
`color-name`, the `Shai-Hulud` self-propagating worm, etc.) were typically
caught and yanked within hours of publish. Holding new versions for 3 days
before installing them dramatically reduces exposure to 0-day malicious
publishes without meaningfully slowing day-to-day development.

References:
- npm: https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age

## Risk / rollout

- No functional change to application code.
- Only affects fresh installs of versions less than 3 days old.
- Reversible by removing the setting.

_Part of an org-wide supply-chain hardening pass._